### PR TITLE
ci: à l'ouverture d'une PR, auto-assign les reviewers & l'auteur

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,17 @@
+# Configuration file for https://github.com/kentaro-m/auto-assign-action
+
+# Set to true to add reviewers to pull requests
+addReviewers: true
+
+# A list of reviewers to be added to pull requests (GitHub user name)
+reviewers:
+  - paulRbr
+  - raphodn
+
+# A number of reviewers added to the pull request
+# Set 0 to add all the reviewers (default: 0)
+numberOfReviewers: 0
+
+# Set to true to add assignees to pull requests
+# Set to 'author' to set the PR creator as the assignee
+addAssignees: author

--- a/.github/workflows/pr-auto-reviewers-and-assignee.yml
+++ b/.github/workflows/pr-auto-reviewers-and-assignee.yml
@@ -1,0 +1,11 @@
+name: PR Auto Reviewers (team) & Assignee (author)
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, reopened]  # will not run on drafts
+
+jobs:
+  add-reviews:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: kentaro-m/auto-assign-action@v2.0.0


### PR DESCRIPTION
### Quoi

Ajout d'une Github Action toute simple qui permet : 
- de mettre automatiquement en reviewer les maintainer du projet
- de mettre automatiquement en assignee l'auteur de la PR

Grâce à https://github.com/kentaro-m/auto-assign-action

### Pourquoi

Pour éviter de devoir le faire manuellement